### PR TITLE
possible solution

### DIFF
--- a/src/app/breadcrumb/breadcrumb.component.html
+++ b/src/app/breadcrumb/breadcrumb.component.html
@@ -1,7 +1,7 @@
 <app-userinfo></app-userinfo>
-<div class="breadcrumb-content row d-flex h-100">
+<div class="breadcrumb-content row d-flex h-100" style="min-height: 0;">
     <app-room-list></app-room-list>
-    <div class="col-9 flex-grow-1 d-flex">
+    <div class="col-9 flex-grow-1 d-flex h-100 overflow-auto">
         <router-outlet></router-outlet>
         <!-- settings/help/column with room&message-->
     </div>

--- a/src/app/breadcrumb/breadcrumb.component.ts
+++ b/src/app/breadcrumb/breadcrumb.component.ts
@@ -3,7 +3,7 @@ import { Component, OnInit } from '@angular/core';
 @Component({
   selector: 'app-breadcrumb',
   templateUrl: './breadcrumb.component.html',
-  host: { 'class': 'container d-flex flex-grow-1 flex-column'},
+  host: { 'class': 'container d-flex flex-grow-1 flex-column', 'style': 'min-height: 0'},
   styleUrls: ['./breadcrumb.component.css']
 })
 export class BreadcrumbComponent implements OnInit {

--- a/src/app/breadcrumb/room/room.component.html
+++ b/src/app/breadcrumb/room/room.component.html
@@ -1,5 +1,5 @@
 
-<div class="message-area h-50">
+<div class="">
 
     <div *ngFor="let crumb of crumbs"
         class="message"
@@ -8,7 +8,7 @@
             @
         </span>
         <span class="d-inline-block message-content"  tabindex="0" data-bs-toggle="tooltip" title="{{crumb.author}}">
-            
+
             {{' '+ crumb.message}}
         </span>
     </div>


### PR DESCRIPTION
as per the last answer here: https://stackoverflow.com/questions/52487743/prevent-flex-item-from-exceeding-parent-height-and-make-scroll-bar-work

I believe breadcrumb component and the breadcrumb-content div are taking on minimum height based on their contents (app-room is large) rather than respect the height of the parent flex box; hence min-height: 0 setting for both.  

from this point, child elements will respect the parent height when given height 100%, and set overflow on the room component container and not the room component itself.

unsure if this is how you want things, but could be a start to understanding and adjust as needed.  